### PR TITLE
Moving variable definitions to bison implementation

### DIFF
--- a/simple.y
+++ b/simple.y
@@ -4,7 +4,13 @@
 #include<string.h>
 #include "type.h"
 #include<ctype.h>
+
+int variable[26];
+procedure_block procedure_info[100];
+int procedure_index;
+
 tries* root_tries = NULL;
+
 tNode *build_operator(char *op,tNodeType t, tNode* left , tNode* right){
 
 	tNode *ptr;

--- a/type.h
+++ b/type.h
@@ -1,3 +1,6 @@
+#ifndef TYPE_H
+#define TYPE_H
+
 // tNodeType: enumarate type describing the type of the node
 typedef enum {t_block,t_expr,t_operator,t_id,t_number,t_procedure,t_condition,t_odd,t_call,t_print} tNodeType;
 
@@ -24,7 +27,5 @@ typedef struct tries{
 
 // struct _Node and tNode are identical
 typedef struct _tNode tNode;
-int variable[26];
-procedure_block procedure_info[100];
-int procedure_index;
 
+#endif


### PR DESCRIPTION
I added a header guard to type.h, and moved the variable definitions (variable, procedure_index, and procedure table) from the header to the yacc/bison implementation to avoid a linker error when linking the generated lex and yacc c files, which each include type.h.